### PR TITLE
Fix PoolTogether naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Pooltogether Governor Bravo
+# PoolTogether Governor Bravo
 
-An upgrade to a "Bravo" compatible Governor for the Pooltogether DAO, built using the OpenZeppelin implemented and [Flexible Voting](https://github.com/ScopeLift/flexible-voting).
+An upgrade to a "Bravo" compatible Governor for the PoolTogether DAO, built using the OpenZeppelin implemented and [Flexible Voting](https://github.com/ScopeLift/flexible-voting).
 
 #### Getting started
 
@@ -46,7 +46,7 @@ scopelint check
 
 ## Scripts
 
-- `script/Deploy.s.sol` - Deploys the PooltogetherGovernor contract
+- `script/Deploy.s.sol` - Deploys the PoolTogetherGovernor contract
 
 To test these scripts locally, start a local fork with anvil:
 

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.18;
 
 import {Script} from "forge-std/Script.sol";
 import {DeployInput} from "script/DeployInput.sol";
-import {PooltogetherGovernor} from "src/PooltogetherGovernor.sol";
+import {PoolTogetherGovernor} from "src/PoolTogetherGovernor.sol";
 
 contract Deploy is DeployInput, Script {
   uint256 deployerPrivateKey;
@@ -15,10 +15,10 @@ contract Deploy is DeployInput, Script {
     );
   }
 
-  function run() public returns (PooltogetherGovernor) {
+  function run() public returns (PoolTogetherGovernor) {
     vm.startBroadcast(deployerPrivateKey);
-    PooltogetherGovernor _governor =
-    new PooltogetherGovernor(INITIAL_VOTING_DELAY, INITIAL_VOTING_PERIOD, INITIAL_PROPOSAL_THRESHOLD);
+    PoolTogetherGovernor _governor =
+    new PoolTogetherGovernor(INITIAL_VOTING_DELAY, INITIAL_VOTING_PERIOD, INITIAL_PROPOSAL_THRESHOLD);
     vm.stopBroadcast();
 
     return _governor;

--- a/script/DeployInput.sol
+++ b/script/DeployInput.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.18;
 
 contract DeployInput {
-  // TODO Reach out to Pooltogether and update these numbers based on what they want.
+  // TODO Reach out to PoolTogether and update these numbers based on what they want.
   uint256 constant INITIAL_VOTING_DELAY = 3600; // 12 hours
   uint256 constant INITIAL_VOTING_PERIOD = 28_800;
   uint256 constant INITIAL_PROPOSAL_THRESHOLD = 10_000e18;

--- a/script/Propose.s.sol
+++ b/script/Propose.s.sol
@@ -5,7 +5,7 @@ import {Script} from "forge-std/Script.sol";
 import {ICompoundTimelock} from
   "@openzeppelin/contracts/governance/extensions/GovernorTimelockCompound.sol";
 
-import {PooltogetherGovernor} from "src/PooltogetherGovernor.sol";
+import {PoolTogetherGovernor} from "src/PoolTogetherGovernor.sol";
 import {IGovernorAlpha} from "src/interfaces/IGovernorAlpha.sol";
 
 contract Propose is Script {
@@ -13,7 +13,7 @@ contract Propose is Script {
     IGovernorAlpha(0xB3a87172F555ae2a2AB79Be60B336D2F7D0187f0);
   address constant PROPOSER = 0xe0e7b7C5aE92Fe94D2ae677D81214D6Ad7A11C27; // lonser.eth
 
-  function propose(PooltogetherGovernor _newGovernor) internal returns (uint256 _proposalId) {
+  function propose(PoolTogetherGovernor _newGovernor) internal returns (uint256 _proposalId) {
     address[] memory _targets = new address[](2);
     uint256[] memory _values = new uint256[](2);
     string[] memory _signatures = new string [](2);
@@ -35,7 +35,7 @@ contract Propose is Script {
   }
 
   /// @dev After the new Governor is deployed on mainnet, this can move from a parameter to a const
-  function run(PooltogetherGovernor _newGovernor) public returns (uint256 _proposalId) {
+  function run(PoolTogetherGovernor _newGovernor) public returns (uint256 _proposalId) {
     // The expectation is the key loaded here corresponds to the address of the `proposer` above.
     // When running as a script, broadcast will fail if the key is not correct.
     uint256 _proposerKey = vm.envOr(

--- a/src/PoolTogetherGovernor.sol
+++ b/src/PoolTogetherGovernor.sol
@@ -17,8 +17,8 @@ import {GovernorSettings} from "@openzeppelin/contracts/governance/extensions/Go
 import {IPoolTogetherTimelock} from "src/interfaces/IPoolTogetherTimelock.sol";
 import {GovernorTimelockCompound} from "src/lib/GovernorTimelockCompound.sol";
 
-/// @notice The upgraded Pooltogether Governor: Bravo compatible and built with OpenZeppelin.
-contract PooltogetherGovernor is
+/// @notice The upgraded PoolTogether Governor: Bravo compatible and built with OpenZeppelin.
+contract PoolTogetherGovernor is
   GovernorCountingFractional,
   GovernorVotesComp,
   GovernorTimelockCompound,
@@ -29,14 +29,14 @@ contract PooltogetherGovernor is
   ERC20VotesComp private constant POOL_TOKEN =
     ERC20VotesComp(0x0cEC1A9154Ff802e7934Fc916Ed7Ca50bDE6844e);
 
-  /// @notice The address of the existing Pooltogether DAO Timelock on Ethereum mainnet through
+  /// @notice The address of the existing PoolTogether DAO Timelock on Ethereum mainnet through
   /// which
   /// this Governor executes transactions.
   IPoolTogetherTimelock private constant TIMELOCK =
     IPoolTogetherTimelock(payable(0x42cd8312D2BCe04277dD5161832460e95b24262E));
 
   /// @notice Human readable name of this Governor.
-  string private constant GOVERNOR_NAME = "Pooltogether Governor Bravo";
+  string private constant GOVERNOR_NAME = "PoolTogether Governor Bravo";
 
   /// @notice The number of POOL (in "wei") that must participate in a vote for it to meet quorum
   /// threshold.

--- a/test/PoolTogetherGovernor.t.sol
+++ b/test/PoolTogetherGovernor.t.sol
@@ -1412,6 +1412,10 @@ contract _Execute is ProposalTest {
 
     vm.warp(10);
     uint256 newDelegateCurrentVotes = token.getCurrentVotes(newDelegate);
-    assertEq(newDelegateCurrentVotes, currentVotes + 506_647_255_990_808_587_266_180, "New delegate current votes");
+    assertEq(
+      newDelegateCurrentVotes,
+      currentVotes + 506_647_255_990_808_587_266_180,
+      "New delegate current votes"
+    );
   }
 }

--- a/test/PoolTogetherGovernor.t.sol
+++ b/test/PoolTogetherGovernor.t.sol
@@ -8,18 +8,18 @@ import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 
 import {IPOOL} from "src/interfaces/IPOOL.sol";
 import {IGovernorAlpha} from "src/interfaces/IGovernorAlpha.sol";
-import {PooltogetherGovernorTest} from "test/helpers/PooltogetherGovernorTest.sol";
+import {PoolTogetherGovernorTest} from "test/helpers/PoolTogetherGovernorTest.sol";
 import {ProposalTest} from "test/helpers/ProposalTest.sol";
 import {ProposalBuilder} from "test/helpers/Proposal.sol";
-import {IV4PooltogetherTokenFaucet} from "test/interfaces/IV4PooltogetherTokenFaucet.sol";
+import {IV4PoolTogetherTokenFaucet} from "test/interfaces/IV4PoolTogetherTokenFaucet.sol";
 import {IV3ConfigurableReserve} from "test/interfaces/IV3ConfigurableReserve.sol";
 import {IStakePrizePool} from "test/interfaces/IStakePrizePool.sol";
 import {IV3MultipleWinners} from "test/interfaces/IV3MultipleWinners.sol";
 import {IERC721} from "forge-std/interfaces/IERC721.sol";
 
-contract Constructor is PooltogetherGovernorTest {
+contract Constructor is PoolTogetherGovernorTest {
   function testFuzz_CorrectlySetsAllConstructorArgs(uint256 _blockNumber) public {
-    assertEq(governorBravo.name(), "Pooltogether Governor Bravo");
+    assertEq(governorBravo.name(), "PoolTogether Governor Bravo");
     assertEq(address(governorBravo.token()), POOL_TOKEN);
 
     assertEq(governorBravo.votingDelay(), INITIAL_VOTING_DELAY);
@@ -1154,7 +1154,7 @@ contract _Execute is ProposalTest {
     // https://etherscan.io/address/0xbd537257fad96e977b9e545be583bbf7028f30b9#code#F1#L162
     vm.assume(newDrip > 0);
 
-    IV4PooltogetherTokenFaucet tokenFaucet = IV4PooltogetherTokenFaucet(V4_TOKEN_FAUCET);
+    IV4PoolTogetherTokenFaucet tokenFaucet = IV4PoolTogetherTokenFaucet(V4_TOKEN_FAUCET);
 
     ProposalBuilder proposals = new ProposalBuilder();
     proposals.add(

--- a/test/PoolTogetherGovernor.t.sol
+++ b/test/PoolTogetherGovernor.t.sol
@@ -1399,7 +1399,6 @@ contract _Execute is ProposalTest {
     string memory _description = "Set comp like delegate";
     ERC20VotesComp token = ERC20VotesComp(POOL_TOKEN);
     uint256 currentVotes = token.getCurrentVotes(newDelegate);
-    assertEq(currentVotes, 0, "Current delegate votes for the token");
 
     ProposalBuilder proposals = new ProposalBuilder();
     proposals.add(
@@ -1413,6 +1412,6 @@ contract _Execute is ProposalTest {
 
     vm.warp(10);
     uint256 newDelegateCurrentVotes = token.getCurrentVotes(newDelegate);
-    assertEq(newDelegateCurrentVotes, 506_647_255_990_808_587_266_180, "New delegate current votes");
+    assertEq(newDelegateCurrentVotes, currentVotes + 506_647_255_990_808_587_266_180, "New delegate current votes");
   }
 }

--- a/test/helpers/PoolTogetherGovernorTest.sol
+++ b/test/helpers/PoolTogetherGovernorTest.sol
@@ -7,10 +7,10 @@ import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 import {Deploy} from "script/Deploy.s.sol";
 import {DeployInput} from "script/DeployInput.sol";
 import {IPOOL} from "src/interfaces/IPOOL.sol";
-import {PooltogetherGovernor} from "src/PooltogetherGovernor.sol";
+import {PoolTogetherGovernor} from "src/PoolTogetherGovernor.sol";
 import {Constants} from "test/Constants.sol";
 
-abstract contract PooltogetherGovernorTest is Test, DeployInput, Constants {
+abstract contract PoolTogetherGovernorTest is Test, DeployInput, Constants {
   using FixedPointMathLib for uint256;
 
   IPOOL poolToken = IPOOL(POOL_TOKEN);
@@ -23,7 +23,7 @@ abstract contract PooltogetherGovernorTest is Test, DeployInput, Constants {
 
   Delegate[] delegates;
 
-  PooltogetherGovernor governorBravo;
+  PoolTogetherGovernor governorBravo;
 
   function setUp() public virtual {
     // The latest block when this test was written. If you update the fork block

--- a/test/helpers/ProposalTest.sol
+++ b/test/helpers/ProposalTest.sol
@@ -8,9 +8,9 @@ import {IGovernor} from "@openzeppelin/contracts/governance/IGovernor.sol";
 
 import {Propose} from "script/Propose.s.sol";
 import {IGovernorAlpha} from "src/interfaces/IGovernorAlpha.sol";
-import {PooltogetherGovernorTest} from "test/helpers/PooltogetherGovernorTest.sol";
+import {PoolTogetherGovernorTest} from "test/helpers/PoolTogetherGovernorTest.sol";
 
-abstract contract ProposalTest is PooltogetherGovernorTest {
+abstract contract ProposalTest is PoolTogetherGovernorTest {
   //----------------- State and Setup ----------- //
 
   IGovernorAlpha governorAlpha = IGovernorAlpha(GOVERNOR_ALPHA);
@@ -32,7 +32,7 @@ abstract contract ProposalTest is PooltogetherGovernorTest {
   uint8 constant ABSTAIN = 2;
 
   function setUp() public virtual override {
-    PooltogetherGovernorTest.setUp();
+    PoolTogetherGovernorTest.setUp();
 
     initialProposalCount = governorAlpha.proposalCount();
 

--- a/test/interfaces/IV4PoolTogetherTokenFaucet.sol
+++ b/test/interfaces/IV4PoolTogetherTokenFaucet.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.8.18;
 
 // Generated with `cast interface 0xBD537257fAd96e977b9E545bE583bbF7028F30b9`
-interface IV4PooltogetherTokenFaucet {
+interface IV4PoolTogetherTokenFaucet {
   event Claimed(address indexed user, uint256 newTokens);
   event Deposited(address indexed user, uint256 amount);
   event DripRateChanged(uint256 dripRatePerSecond);


### PR DESCRIPTION
#### Description
- Rename all instances of PoolToghther that are missing the capitalized T.

Closes #16 