### PR TITLE
Update tests to run against live proposal data

### DIFF
--- a/script/Propose.s.sol
+++ b/script/Propose.s.sol
@@ -11,7 +11,7 @@ import {IGovernorAlpha} from "src/interfaces/IGovernorAlpha.sol";
 contract Propose is Script {
   IGovernorAlpha constant GOVERNOR_ALPHA =
     IGovernorAlpha(0xB3a87172F555ae2a2AB79Be60B336D2F7D0187f0);
-  address constant PROPOSER = 0xe0e7b7C5aE92Fe94D2ae677D81214D6Ad7A11C27; // lonser.eth
+  address PROPOSER = 0xe0e7b7C5aE92Fe94D2ae677D81214D6Ad7A11C27; // lonser.eth
 
   function propose(PoolTogetherGovernor _newGovernor) internal returns (uint256 _proposalId) {
     address[] memory _targets = new address[](2);

--- a/test/helpers/PoolTogetherGovernorTest.sol
+++ b/test/helpers/PoolTogetherGovernorTest.sol
@@ -28,7 +28,7 @@ abstract contract PoolTogetherGovernorTest is Test, DeployInput, Constants {
   function setUp() public virtual {
     // The latest block when this test was written. If you update the fork block
     // make sure to also update the top 6 delegates below.
-    uint256 _forkBlock = 17_892_867;
+    uint256 _forkBlock = 17_927_962;
     vm.createSelectFork(vm.rpcUrl("mainnet"), _forkBlock);
 
     // Taken from https://www.tally.xyz/gov/pooltogether/delegates?sort=voting_power_desc.

--- a/test/helpers/TestableProposeScript.sol
+++ b/test/helpers/TestableProposeScript.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.17;
+
+import {Propose} from "script/Propose.s.sol";
+
+/// @dev An extension of the proposal script for use in tests
+contract TestableProposeScript is Propose {
+  /// @dev Used only in the context of testing in order to allow an alternate address to be the
+  /// proposer. This is needed when testing with live proposal data, because the Governor only
+  /// allows each proposer to have one live proposal at a time.
+  function overrideProposerForTests(address _testProposer) external {
+    PROPOSER = _testProposer;
+  }
+}


### PR DESCRIPTION
The upgrade proposal is now [live](https://www.tally.xyz/gov/pooltogether/proposal/79). We update the test suite to run against the live, onchain proposal data to ensure no errors were introduced in the proposal process.